### PR TITLE
matlab support

### DIFF
--- a/lua/plugins/language-server.lua
+++ b/lua/plugins/language-server.lua
@@ -13,6 +13,7 @@ return {
         ensure_installed = {
           "lua_ls", "pyright", "gopls",
           "nim_langserver",
+          "matlab_ls",
         },
       }
 
@@ -31,6 +32,18 @@ return {
       lsp.pyright.setup{}
       lsp.nim_langserver.setup{}
       lsp.gopls.setup{}
+      lsp.matlab_ls.setup({
+        filetypes = {"matlab"},
+        settings = {
+          matlab = {
+            indexWorkspace = true,
+            installPath = "~/Apps/MATLAB/R2024b/",
+            matlabConnectionTiming = "onStart",
+            telemetry = false,
+          },
+        },
+        single_file_support = true
+      })
 
     end
   },

--- a/lua/plugins/treesitter.lua
+++ b/lua/plugins/treesitter.lua
@@ -5,7 +5,7 @@ return {
       ensure_installed = {
         'lua', 'markdown', 'markdown_inline', --necessary parsers for buf.hover()
         'vim', 'regex', 'bash', --necessary parsers for noice
-        'python', 'nim', 'go', --languages
+        'python', 'nim', 'go', 'matlab', --languages
       },
     }
   end,


### PR DESCRIPTION
Error is solved by just adding matlab to path (even though it shouldn't need to be there because of `installPath`).